### PR TITLE
Add ARM64 support using QEMU

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -7,11 +7,23 @@ on:
 
 jobs:
   build-and-push:
+    name: Publish Docker Images
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+
 
     steps:
-      - name: Checkout repository
+      - name: Checkout head
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -27,11 +39,17 @@ jobs:
         id: get_version
         run: echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV
 
+      - name: Echo metadata
+        run: |
+          echo "version: ${{ env.VERSION }}"
+          echo "sha: ${{ github.sha }}"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}/conscript:latest
             ghcr.io/${{ github.repository }}/conscript:${{ env.VERSION }}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow to enhance the Docker image publishing process. The most important changes involve adding permissions, setting up QEMU, and including metadata echoing.

Enhancements to Docker image publishing:

* [`.github/workflows/github-deploy.yml`](diffhunk://#diff-38a0d463549a30b36331e27f9371f9492527e94e7ba3c8dced2e5e35296d6118R10-R26): Added permissions for `id-token`, `contents`, and `packages` to enable secure access and writing.
* [`.github/workflows/github-deploy.yml`](diffhunk://#diff-38a0d463549a30b36331e27f9371f9492527e94e7ba3c8dced2e5e35296d6118R10-R26): Added steps to set up QEMU for cross-platform builds.
* [`.github/workflows/github-deploy.yml`](diffhunk://#diff-38a0d463549a30b36331e27f9371f9492527e94e7ba3c8dced2e5e35296d6118R42-R52): Included metadata echoing to display the version and commit SHA during the workflow run.
* [`.github/workflows/github-deploy.yml`](diffhunk://#diff-38a0d463549a30b36331e27f9371f9492527e94e7ba3c8dced2e5e35296d6118R42-R52): Updated Docker build and push step to support multiple platforms (`linux/amd64`, `linux/arm64`).